### PR TITLE
Optionally su if lets_encrypt_user is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Configurable options (copy into deploy.rb), shown here with examples:
 # default value: :web
 set :lets_encrypt_roles, :lets_encrypt
 
+# Optionally set the user to use when installing on the remote system
+# default value: nil
+set :lets_encrypt_user, nil
+
 # Set it to true to use let's encrypt staging servers
 # default value: false
 set :lets_encrypt_test, true

--- a/lib/capistrano/tasks/lets-encrypt.rake
+++ b/lib/capistrano/tasks/lets-encrypt.rake
@@ -61,34 +61,36 @@ namespace :lets_encrypt do
   end
 
   def authorize(domain)
-    wrapper.log "Authorizing #{domain.blue}."
-    authorization = client.authorize(domain: domain)
+    as_encrypt_user do
+      wrapper.log "Authorizing #{domain.blue}."
+      authorization = client.authorize(domain: domain)
 
-    challenge = authorization.http01
-    challenge_public_path = fetch(:lets_encrypt_challenge_public_path)
-    challenge_path = File.join(challenge_public_path, File.dirname(challenge.filename))
-    challenge_file_path = File.join(challenge_public_path, challenge.filename)
-    execute :mkdir, '-pv', challenge_path
+      challenge = authorization.http01
+      challenge_public_path = fetch(:lets_encrypt_challenge_public_path)
+      challenge_path = File.join(challenge_public_path, File.dirname(challenge.filename))
+      challenge_file_path = File.join(challenge_public_path, challenge.filename)
+      execute :mkdir, '-pv', challenge_path
 
-    wrapper.log "Writing challenge to #{challenge_file_path}", :debug
+      wrapper.log "Writing challenge to #{challenge_file_path}", :debug
 
-    execute :echo, "\"#{challenge.file_content}\" > #{challenge_file_path}"
+      execute :echo, "\"#{challenge.file_content}\" > #{challenge_file_path}"
 
-    challenge.request_verification
+      challenge.request_verification
 
-    5.times do
-      wrapper.log "Checking verification...", :debug
-      sleep 1
-      break if challenge.verify_status != 'pending'
-    end
-    if challenge.verify_status == 'valid'
-      wrapper.log "Authorization successful for #{domain.green}"
-      execute :rm, '-f', challenge_file_path
-      true
-    else
-      wrapper.log "Authorization error for #{domain.red}", :error
-      wrapper.log challenge.error['detail']
-      false
+      5.times do
+        wrapper.log "Checking verification...", :debug
+        sleep 1
+        break if challenge.verify_status != 'pending'
+      end
+      if challenge.verify_status == 'valid'
+        wrapper.log "Authorization successful for #{domain.green}"
+        execute :rm, '-f', challenge_file_path
+        true
+      else
+        wrapper.log "Authorization error for #{domain.red}", :error
+        wrapper.log challenge.error['detail']
+        false
+      end
     end
   end
 
@@ -100,11 +102,29 @@ namespace :lets_encrypt do
   end
 
   def upload_certs(domain)
-    execute :mkdir, '-pv', "#{fetch(:lets_encrypt_output_path)}/#{domain}"
-    upload! local_private_key_path, private_key_path
-    upload! local_fullchain_path, fullchain_path
-    upload! local_certificate_path, certificate_path
-    upload! local_chain_path, chain_path
+    as_encrypt_user do
+      execute :mkdir, '-pv', "#{fetch(:lets_encrypt_output_path)}/#{domain}"
+      safe_upload! local_private_key_path, private_key_path
+      safe_upload! local_fullchain_path, fullchain_path
+      safe_upload! local_certificate_path, certificate_path
+      safe_upload! local_chain_path, chain_path
+    end
+  end
+
+  def as_encrypt_user(&block)
+    if fetch(:lets_encrypt_user)
+      as fetch(:lets_encrypt_user) do
+        yield
+      end
+    else
+      yield
+    end
+  end
+
+  def safe_upload!(from, to)
+    tempname = "/tmp/#{Time.now.to_f}"
+    upload! from, tempname
+    sudo :mv, tempname, to
   end
 
   # Helpers


### PR DESCRIPTION
This change allows the user to specify e.g. `set :lets_encrypt_user, "root"` to have the tasks executed under a different user (root most likely).
