### PR TITLE
Have to explicitly require colorize for acme-client

### DIFF
--- a/lib/capistrano/tasks/lets-encrypt.rake
+++ b/lib/capistrano/tasks/lets-encrypt.rake
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'letsencrypt/cli/acme_wrapper'
+require 'colorize'
 
 namespace :lets_encrypt do
 


### PR DESCRIPTION
I got errors when not requiring colorize explicitly. Strictly speaking, this is an error in acme-client, but I reckon we can fix it here.
