### PR TITLE
Expand lets_encrypt_account_key, so we can refer home dir

### DIFF
--- a/lib/capistrano/tasks/lets-encrypt.rake
+++ b/lib/capistrano/tasks/lets-encrypt.rake
@@ -158,7 +158,7 @@ namespace :lets_encrypt do
 
   def options
     @options ||= {
-      account_key: fetch(:lets_encrypt_account_key),
+      account_key: File.expand_path(fetch(:lets_encrypt_account_key)),
       test: fetch(:lets_encrypt_test),
       log_level: "info",
       color: true,


### PR DESCRIPTION
Minor change - Allows us to use `set :lets_encrypt_account_key, "~/certs/#{fetch(:lets_encrypt_email)}.account_key.pem"` without having to manually expand path.
